### PR TITLE
Add sparse matrix, add script of randomForest and boosting from xgboost

### DIFF
--- a/0-init/1-install.txt
+++ b/0-init/1-install.txt
@@ -10,7 +10,8 @@ apt-get update
 apt-get install r-base-dev libcurl4-openssl-dev
 
 R --vanilla << EOF
-install.packages(c("data.table","readr","randomForest","gbm","glmnet","LiblineaR","ROCR"), repos="http://cran.rstudio.com")
+install.packages(c("data.table","readr","randomForest","gbm","glmnet","LiblineaR","ROCR","Matrix","devtools"), repos="http://cran.rstudio.com")
+devtools::install_github('dmlc/xgboost',subdir='R-package')
 EOF
 
 

--- a/1-linear/1b-glmnet.R
+++ b/1-linear/1b-glmnet.R
@@ -1,9 +1,8 @@
-
 library(readr)
 library(ROCR)
 library(glmnet)
 
-d_train <- read_csv("train-1m.csv")
+d_train <- read_csv("train-10m.csv")
 d_test <- read_csv("test.csv")
 
 for (k in c("Month","DayofMonth","DayOfWeek")) {

--- a/1-linear/1b-glmnet.R
+++ b/1-linear/1b-glmnet.R
@@ -14,7 +14,7 @@ sapply(d_train, class)
 
 
 system.time({
-X_train_test <-  model.matrix(dep_delayed_15min ~ ., data = rbind(d_train, d_test))
+X_train_test <- Matrix::sparse.model.matrix(dep_delayed_15min ~ ., data = rbind(d_train, d_test))
 X_train <- X_train_test[1:nrow(d_train),]
 X_test <- X_train_test[(nrow(d_train)+1):(nrow(d_train)+nrow(d_test)),]
 })

--- a/2-rf/1a-xgboost.R
+++ b/2-rf/1a-xgboost.R
@@ -15,12 +15,13 @@ system.time({
 })
 dim(X_train)
 
-
+# Expose some parameters to make a randomForest model.
 system.time({
   n_proc <- detectCores()
   bst <- xgboost(data = X_train, label = as.numeric(d_train$dep_delayed_15min=='Y'),
-                 nthread = n_proc, nround=1, objective='binary:logistic',
-                 num_parallel_tree=500)
+                 nthread = n_proc, nround=1, max_depth=20,
+                 num_parallel_tree=500,subsample=0.632,
+                 colsample_bytree=1/sqrt(length(X_train@x)/nrow(X_train)))
 })
 
 system.time({

--- a/2-rf/1a-xgboost.R
+++ b/2-rf/1a-xgboost.R
@@ -1,0 +1,33 @@
+library(data.table)
+library(ROCR)
+library(xgboost)
+library(parallel)
+
+set.seed(123)
+
+d_train <- as.data.frame(fread("train-1m.csv"))
+d_test <- as.data.frame(fread("test.csv"))
+
+system.time({
+  X_train_test <- Matrix::sparse.model.matrix(dep_delayed_15min ~ ., data = rbind(d_train, d_test))
+  X_train <- X_train_test[1:nrow(d_train),]
+  X_test <- X_train_test[(nrow(d_train)+1):(nrow(d_train)+nrow(d_test)),]
+})
+dim(X_train)
+
+
+system.time({
+  n_proc <- detectCores()
+  bst <- xgboost(data = X_train, label = as.numeric(d_train$dep_delayed_15min=='Y'),
+                 nthread = n_proc, nround=1, objective='binary:logistic',
+                 num_parallel_tree=500)
+})
+
+system.time({
+  phat <- predict(bst, newdata = X_test)
+})
+rocr_pred <- prediction(phat, d_test$dep_delayed_15min)
+performance(rocr_pred, "auc")
+
+gc()
+sapply(ls(),function(x) object.size(get(x))/1e6)

--- a/3-boosting/1a-xgboost.R
+++ b/3-boosting/1a-xgboost.R
@@ -1,0 +1,33 @@
+library(data.table)
+library(ROCR)
+library(xgboost)
+library(parallel)
+
+set.seed(123)
+
+d_train <- as.data.frame(fread("train-1m.csv"))
+d_test <- as.data.frame(fread("test.csv"))
+
+system.time({
+  X_train_test <- Matrix::sparse.model.matrix(dep_delayed_15min ~ ., data = rbind(d_train, d_test))
+  X_train <- X_train_test[1:nrow(d_train),]
+  X_test <- X_train_test[(nrow(d_train)+1):(nrow(d_train)+nrow(d_test)),]
+})
+dim(X_train)
+
+
+system.time({
+  n_proc <- detectCores()
+  bst <- xgboost(data = X_train, label = as.numeric(d_train$dep_delayed_15min=='Y'),
+                 nthread = n_proc, nround=5, objective='binary:logistic')
+})
+
+system.time({
+  phat <- predict(bst, newdata = X_test)
+})
+rocr_pred <- prediction(phat, d_test$dep_delayed_15min)
+performance(rocr_pred, "auc")
+
+gc()
+sapply(ls(),function(x) object.size(get(x))/1e6)
+

--- a/3-boosting/1a-xgboost.R
+++ b/3-boosting/1a-xgboost.R
@@ -19,7 +19,7 @@ dim(X_train)
 system.time({
   n_proc <- detectCores()
   bst <- xgboost(data = X_train, label = as.numeric(d_train$dep_delayed_15min=='Y'),
-                 nthread = n_proc, nround=5, objective='binary:logistic')
+                 nthread = n_proc, nround=500, objective='binary:logistic')
 })
 
 system.time({

--- a/3-boosting/xgboost.R
+++ b/3-boosting/xgboost.R
@@ -1,0 +1,35 @@
+library(data.table)
+library(ROCR)
+library(xgboost)
+
+set.seed(123)
+
+d_train <- as.data.frame(fread("train-0.1m.csv"))
+d_test <- as.data.frame(fread("test.csv"))
+
+## "Can not handle categorical predictors with more than 53 categories."
+## so need dummy variables/1-hot encoding
+## - but then RF does not treat them as 1 variable
+system.time({
+  X_train_test <- Matrix::sparse.model.matrix(dep_delayed_15min ~ ., data = rbind(d_train, d_test))
+  X_train <- X_train_test[1:nrow(d_train),]
+  X_test <- X_train_test[(nrow(d_train)+1):(nrow(d_train)+nrow(d_test)),]
+})
+dim(X_train)
+
+
+system.time({
+  n_proc <- detectCores()
+  bst <- xgboost(data = X_train, label = d_train$dep_delayed_15min,nthread = n_proc)
+})
+
+
+system.time({
+  phat <- predict(bst, newdata = X_test)
+})
+rocr_pred <- prediction(phat, d_test$dep_delayed_15min)
+performance(rocr_pred, "auc")
+
+gc()
+sapply(ls(),function(x) object.size(get(x))/1e6)
+

--- a/3-boosting/xgboost.R
+++ b/3-boosting/xgboost.R
@@ -1,15 +1,13 @@
 library(data.table)
 library(ROCR)
 library(xgboost)
+library(parallel)
 
 set.seed(123)
 
-d_train <- as.data.frame(fread("train-0.1m.csv"))
+d_train <- as.data.frame(fread("train-1m.csv"))
 d_test <- as.data.frame(fread("test.csv"))
 
-## "Can not handle categorical predictors with more than 53 categories."
-## so need dummy variables/1-hot encoding
-## - but then RF does not treat them as 1 variable
 system.time({
   X_train_test <- Matrix::sparse.model.matrix(dep_delayed_15min ~ ., data = rbind(d_train, d_test))
   X_train <- X_train_test[1:nrow(d_train),]
@@ -20,9 +18,9 @@ dim(X_train)
 
 system.time({
   n_proc <- detectCores()
-  bst <- xgboost(data = X_train, label = d_train$dep_delayed_15min,nthread = n_proc)
+  bst <- xgboost(data = X_train, label = as.numeric(d_train$dep_delayed_15min=='Y'),
+                 nthread = n_proc, nround=5, objective='binary:logistic')
 })
-
 
 system.time({
   phat <- predict(bst, newdata = X_test)


### PR DESCRIPTION
- With sparse matrix, `glmnet` in R should not crash even on 10M data.
- The randomForest model is also supported in `xgboost`, and on my own test, it is faster than H2O (500 secs with 8cores on 1M data). I suggest to fix some parameters (e.g. the max depth of the tree) for each tree to make a fairer comparison.
- The current boosting script is a sample of `xgboost`. Further setting on the parameters is needed. 
