### PR TITLE
Basic functionality for Rborist.

### DIFF
--- a/2-rf/Rborist.R
+++ b/2-rf/Rborist.R
@@ -1,0 +1,55 @@
+library(data.table)
+library(Rborist)
+library(ROCR)
+
+dx_train <- as.data.frame(fread("train-1m.csv"))
+dx_test <- as.data.frame(fread("test.csv"))
+
+dt_train <- dx_train
+dt_test <- dx_test
+
+# Rborist 0-1.1 only accepts factor and numeric predictors or response:
+#
+facCols <- c("UniqueCarrier", "Origin","Dest", "Month", "DayofMonth", "DayOfWeek")
+
+responseCol <- "dep_delayed_15min"
+numCols <- c("DepTime","Distance")
+
+for (k in facCols) {
+  dt_train[[k]] <- as.factor(dx_train[[k]])
+  dt_test[[k]] <- as.factor(dx_test[[k]])
+}
+
+dt_train[[responseCol]] <- as.factor(dx_train[[responseCol]])
+dt_test[[responseCol]] <- as.factor(dx_test[[responseCol]])
+
+for (k in numCols) {
+  dt_train[[k]] <- as.numeric(dx_train[[k]])
+  dt_test[[k]] <- as.numeric(dx_test[[k]])
+}
+
+rm(dx_train)
+gc()
+
+summary(dt_train)
+
+Xnames <- names(dt_train)[which(names(dt_train) != responseCol)]
+
+
+
+st <- system.time({
+  md <- Rborist(dt_train[, Xnames], dt_train[, responseCol], nTree = 500)
+})
+
+system.time({
+  phat <- predict(md, newdata=dt_test[, Xnames], ctgCensus="prob")$ctgCensus[,"Y"]
+})
+
+rocr_pred <- prediction(phat, dt_test$dep_delayed_15min == "Y")
+perf <- performance(rocr_pred, "auc")
+
+gc()
+
+
+
+


### PR DESCRIPTION
Benchmark entry for Rborist 0-1.1.  This version can be built from Github source, although it is not yet available on CRAN.
Current performance measurements using 4-core AMD, 8GB desktop:
  10^5 rows:  75 seconds, no swapping.
  10^6 rows:  805 seconds, with swapping.
10^7 rows and 32-core performance TBD.
