### PR TITLE
Added AutoML

### DIFF
--- a/automl/h2o.R
+++ b/automl/h2o.R
@@ -1,0 +1,18 @@
+library(h2o)
+
+h2o.init(max_mem_size="60g", nthreads=-1)
+
+dx_train <- h2o.importFile(path = "train-0.1m.csv")
+dx_test <- h2o.importFile(path = "test.csv")
+
+Xnames <- names(dx_train)[which(names(dx_train)!="dep_delayed_15min")]
+
+system.time({
+  md <- h2o.automl(x = Xnames, y = "dep_delayed_15min", training_frame = dx_train)
+})
+
+system.time({
+  print(h2o.auc(h2o.performance(md@leader, dx_test)))
+})
+
+# 0.7284624


### PR DESCRIPTION
As we've discussed in Slack, H2O has recently released some very interesting AutoML functionality. In this case, the leader is the StackedEnsemble generated from a GBM grid, a DL grid, a DRF and an XRT model. On 100k records it trained for a while on some small cloud hardware, and generated a respectable AUC of 0.7284624

```
> md
An object of class "H2OAutoML"
Slot "project_name":
[1] "<default>"

Slot "leader":
Model Details:
==============

H2OBinomialModel: stackedensemble
Model ID:  StackedEnsemble_model_1496028880431_2818 
NULL


H2OBinomialMetrics: stackedensemble
** Reported on training data. **

MSE:  0.06495612
RMSE:  0.2548649
LogLoss:  0.2435769
Mean Per-Class Error:  0.07056041
AUC:  0.9872952
Gini:  0.9745905

Confusion Matrix (vertical: actual; across: predicted) for F1-optimal threshold:
           N     Y    Error         Rate
N      54777  1849 0.032653  =1849/56626
Y       1450 11918 0.108468  =1450/13368
Totals 56227 13767 0.047133  =3299/69994

Maximum Metrics: Maximum metrics at their respective thresholds
                        metric threshold    value idx
1                       max f1  0.299564 0.878423 218
2                       max f2  0.243801 0.912848 242
3                 max f0point5  0.362489 0.896238 193
4                 max accuracy  0.313673 0.953653 213
5                max precision  0.974294 1.000000   0
6                   max recall  0.132957 1.000000 309
7              max specificity  0.974294 1.000000   0
8             max absolute_mcc  0.299564 0.849339 218
9   max min_per_class_accuracy  0.253667 0.943118 237
10 max mean_per_class_accuracy  0.247323 0.944984 240

Gains/Lift Table: Extract with `h2o.gainsLift(<model>, <data>)` or `h2o.gainsLift(<model>, valid=<T/F>, xval=<T/F>)`
H2OBinomialMetrics: stackedensemble
** Reported on validation data. **

MSE:  0.1327237
RMSE:  0.3643127
LogLoss:  0.4226191
Mean Per-Class Error:  0.3271404
AUC:  0.7433911
Gini:  0.4867822

Confusion Matrix (vertical: actual; across: predicted) for F1-optimal threshold:
           N    Y    Error         Rate
N       9287 2974 0.242558  =2974/12261
Y       1166 1666 0.411723   =1166/2832
Totals 10453 4640 0.274299  =4140/15093

Maximum Metrics: Maximum metrics at their respective thresholds
                        metric threshold    value idx
1                       max f1  0.196506 0.445931 257
2                       max f2  0.114152 0.591573 329
3                 max f0point5  0.307013 0.439652 188
4                 max accuracy  0.579457 0.822434  82
5                max precision  0.950060 1.000000   0
6                   max recall  0.048541 1.000000 396
7              max specificity  0.950060 1.000000   0
8             max absolute_mcc  0.272812 0.299325 207
9   max min_per_class_accuracy  0.165504 0.672539 281
10 max mean_per_class_accuracy  0.156244 0.677032 289

Gains/Lift Table: Extract with `h2o.gainsLift(<model>, <data>)` or `h2o.gainsLift(<model>, valid=<T/F>, xval=<T/F>)`


Slot "leaderboard":
                                             model_id      auc  logloss
1            StackedEnsemble_model_1496028880431_2818 0.742023 0.424990
2  GBM_grid__a70036165806366cd146a852765f4af0_model_3 0.724540 0.472045
3  GBM_grid__a70036165806366cd146a852765f4af0_model_1 0.722181 0.438297
4  GBM_grid__a70036165806366cd146a852765f4af0_model_0 0.720750 0.475918
5                           DRF_model_1496028880431_4 0.718733 0.471836
6                         XRT_model_1496028880431_366 0.718564 0.439938
7   DL_grid__a70036165806366cd146a852765f4af0_model_0 0.715729 0.453427
8   DL_grid__a70036165806366cd146a852765f4af0_model_1 0.715312 0.453516
9  GBM_grid__a70036165806366cd146a852765f4af0_model_8 0.712989 0.443795
10 GBM_grid__a70036165806366cd146a852765f4af0_model_4 0.711725 0.457926
11  DL_grid__a70036165806366cd146a852765f4af0_model_2 0.711247 0.472706
12 GLM_grid__a70036165806366cd146a852765f4af0_model_0 0.709769 0.443991
13 GLM_grid__a70036165806366cd146a852765f4af0_model_1 0.709769 0.443991
14 GBM_grid__a70036165806366cd146a852765f4af0_model_6 0.705461 0.468157
15 GBM_grid__a70036165806366cd146a852765f4af0_model_2 0.703969 0.444650
16 GBM_grid__a70036165806366cd146a852765f4af0_model_5 0.697802 0.483724
17  DL_grid__a70036165806366cd146a852765f4af0_model_4 0.691404 0.497545
18 GBM_grid__a70036165806366cd146a852765f4af0_model_7 0.668311 0.897990
19  DL_grid__a70036165806366cd146a852765f4af0_model_3 0.658246 0.647369
```